### PR TITLE
Added allow-all (*) value to allowedOrigins and allowedHeaders. Normalised allowedMethods case

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,11 @@ Stack middleware:
 use Asm89\Stack\Cors;
 
 $app = new Cors($app, array(
+    // you can use array('*') to allow any headers
     'allowedHeaders'      => array('x-allowed-header', 'x-other-allowed-header'),
+    // you can use array('*') to allow any methods
     'allowedMethods'      => array('DELETE', 'GET', 'POST', 'PUT'),
+    // you can use array('*') to allow requests from any origin
     'allowedOrigins'      => array('localhost'),
     'exposedHeaders'      => false,
     'maxAge'              => false,

--- a/src/Asm89/Stack/Cors.php
+++ b/src/Asm89/Stack/Cors.php
@@ -8,7 +8,15 @@ use Symfony\Component\HttpFoundation\Response;
 
 class Cors implements HttpKernelInterface
 {
+    /**
+     * @var \Symfony\Component\HttpKernel\HttpKernelInterface
+     */
     private $app;
+
+    /**
+     * @var \Asm89\Stack\CorsService
+     */
+    private $cors;
 
     private $defaultOptions = array(
         'allowedHeaders'      => array(),
@@ -42,6 +50,6 @@ class Cors implements HttpKernelInterface
 
         $response = $this->app->handle($request, $type, $catch);
 
-        return $this->cors->addActualRequestHeaders($response, $request->headers->get('Origin'));
+        return $this->cors->addActualRequestHeaders($response, $request);
     }
 }

--- a/src/Asm89/Stack/CorsService.php
+++ b/src/Asm89/Stack/CorsService.php
@@ -12,16 +12,44 @@ class CorsService
 
     public function __construct(array $options = array())
     {
-        $this->options = $options;
+        $this->options = $this->normalizeOptions($options);
+    }
+
+    private function normalizeOptions(array $options = array())
+    {
+
+        $options += array(
+            'allowedOrigins' => array(),
+            'supportsCredentials' => false,
+            'allowedHeaders' => array(),
+            'exposedHeaders' => array(),
+            'allowedMethods' => array(),
+            'maxAge' => 0,
+        );
+
+        // normalize array('*') to true
+        if (in_array('*', $options['allowedOrigins'])) {
+          $options['allowedOrigins'] = true;
+        }
+        if (in_array('*', $options['allowedHeaders'])) {
+          $options['allowedHeaders'] = true;
+        } else {
+          $options['allowedHeaders'] = array_map('strtolower', $options['allowedHeaders']);
+        }
+
+        if (in_array('*', $options['allowedMethods'])) {
+          $options['allowedMethods'] = true;
+        } else {
+          $options['allowedMethods'] = array_map('strtoupper', $options['allowedMethods']);
+        }
+
+        return $options;
     }
 
     public function isActualRequestAllowed(Request $request)
     {
-        $origin = $request->headers->get('Origin');
-
-        return in_array($origin, $this->options['allowedOrigins']);
+        return $this->checkOrigin($request);
     }
-
 
     public function isCorsRequest(Request $request)
     {
@@ -35,13 +63,13 @@ class CorsService
             && $request->headers->has('Access-Control-Request-Method');
     }
 
-    public function addActualRequestHeaders(Response $response, $origin)
+    public function addActualRequestHeaders(Response $response, Request $request)
     {
-        if ( ! in_array($origin, $this->options['allowedOrigins'])) {
+        if ( ! $this->checkOrigin($request)) {
             return $response;
         }
 
-        $response->headers->set('Access-Control-Allow-Origin', $origin);
+        $response->headers->set('Access-Control-Allow-Origin', $request->headers->get('Origin'));
 
         if ( ! $response->headers->has('Vary')) {
             $response->headers->set('Vary', 'Origin');
@@ -83,27 +111,32 @@ class CorsService
             $response->headers->set('Access-Control-Max-Age', $this->options['maxAge']);
         }
 
-        $response->headers->set('Access-Control-Allow-Methods', implode(', ', $this->options['allowedMethods']));
+        $allowMethods = $this->options['allowedMethods'] === true
+            ? strtoupper($request->headers->get('Access-Control-Request-Method'))
+            : implode(', ', $this->options['allowedMethods']);
+        $response->headers->set('Access-Control-Allow-Methods', $allowMethods);
 
-        $response->headers->set('Access-Control-Allow-Headers', $request->headers->get('Access-Control-Request-Headers'));
+        $allowHeaders = $this->options['allowedHeaders'] === true
+            ? strtoupper($request->headers->get('Access-Control-Request-Headers'))
+            : implode(', ', $this->options['allowedHeaders']);
+        $response->headers->set('Access-Control-Allow-Headers', $allowHeaders);
 
         return $response;
     }
 
     private function checkPreflightRequestConditions(Request $request)
     {
-        $origin = $request->headers->get('Origin');
-        if ( ! in_array($origin, $this->options['allowedOrigins'])) {
+        if ( ! $this->checkOrigin($request)) {
             return $this->createBadRequestResponse(403, 'Origin not allowed');
         }
 
-        $method = $request->headers->get('Access-Control-Request-Method');
-        if ( ! in_array($method, $this->options['allowedMethods'])) {
+        if ( ! $this->checkMethod($request)) {
             return $this->createBadRequestResponse(405, 'Method not allowed');
         }
 
         $requestHeaders = array();
-        if ($request->headers->has('Access-Control-Request-Headers')) {
+        // if allowedHeaders has been set to true ('*' allow all flag) just skip this check
+        if ($this->options['allowedHeaders'] !== true && $request->headers->has('Access-Control-Request-Headers')) {
             $headers        = strtolower($request->headers->get('Access-Control-Request-Headers'));
             $requestHeaders = explode(',', $headers);
 
@@ -121,4 +154,25 @@ class CorsService
     {
         return new Response($reason, $code);
     }
+
+    private function checkOrigin(Request $request) {
+        if ($this->options['allowedOrigins'] === true) {
+            // allow all '*' flag
+            return true;
+        }
+        $origin = $request->headers->get('Origin');
+
+        return in_array($origin, $this->options['allowedOrigins']);
+    }
+
+    private function checkMethod(Request $request) {
+        if ($this->options['allowedMethods'] === true) {
+            // allow all '*' flag
+            return true;
+        }
+
+        $requestMethod = strtoupper($request->headers->get('Access-Control-Request-Method'));
+        return in_array($requestMethod, $this->options['allowedMethods']);
+    }
+
 }


### PR DESCRIPTION
Thanks for this project! :)

First of all, just an fyi that there's a separate discussion in the NelmioCorsBundle to abstract away its functionality so that we could reuse it: https://github.com/nelmio/NelmioCorsBundle/issues/14

Until that gets fixed I wanted to have support for the \* wildcard in origins and headers.

Let me know what you think
