### PR TITLE
Added --coverage-text to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,4 +7,4 @@ php:
 
 before_script: composer install --dev
 
-script: phpunit
+script: phpunit --coverage-text


### PR DESCRIPTION
FOSRestBundle has this in their travis file: https://github.com/FriendsOfSymfony/FOSRestBundle
You then get nice reports in travis log like this: https://travis-ci.org/FriendsOfSymfony/FOSRestBundle/jobs/16047555
The idea is that it'll be easier to strive for 100% code coverage with a nice report like that ;)
