### PR TITLE
Allow Cors to be instantiated without HttpKernelInterface

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ phpunit.xml
 composer.lock
 composer.phar
 /vendor/
+/coverage/

--- a/src/Asm89/Stack/Cors.php
+++ b/src/Asm89/Stack/Cors.php
@@ -27,15 +27,24 @@ class Cors implements HttpKernelInterface
         'supportsCredentials' => false,
     );
 
-    public function __construct(HttpKernelInterface $app, array $options = array())
+    public function __construct(HttpKernelInterface $app = null, array $options = array())
     {
         $this->app  = $app;
         $this->cors = new CorsService(array_merge($this->defaultOptions, $options));
+    }
 
+    public function setApp(HttpKernelInterface $app)
+    {
+        $this->app = $app;
+        return $this;
     }
 
     public function handle(Request $request, $type = HttpKernelInterface::MASTER_REQUEST, $catch = true)
     {
+        if ( ! $this->app) {
+            throw new \RuntimeException("No app found on Cors middleware");
+        }
+
         if ( ! $this->cors->isCorsRequest($request)) {
             return $this->app->handle($request, $type, $catch);
         }

--- a/test/Asm89/Stack/CorsTest.php
+++ b/test/Asm89/Stack/CorsTest.php
@@ -340,6 +340,27 @@ class CorsTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(42, $response->headers->get('Access-Control-Max-Age'));
     }
 
+    /**
+     * @test
+     */
+    public function it_does_not_require_app_on_construction()
+    {
+        $cors = $this->createService();
+        $app = new MockApp(array());
+        $cors->setApp($app);
+        $this->assertTrue($cors->handle(new Request())->isSuccessful());
+    }
+
+    /**
+     * @test
+     * @expectedException RuntimeException
+     */
+    public function it_throws_exception_on_no_app()
+    {
+        $cors = $this->createService();
+        $cors->handle(new Request());
+    }
+
     private function createValidActualRequest()
     {
         $request  = new Request();
@@ -360,6 +381,11 @@ class CorsTest extends PHPUnit_Framework_TestCase
 
     private function createStackedApp(array $options = array(), array $responseHeaders = array())
     {
+        return $this->createService(new MockApp($responseHeaders), $options);
+    }
+
+    private function createService(HttpKernelInterface $app = null, array $options = array())
+    {
         $passedOptions = array_merge(array(
                 'allowedHeaders'      => array('x-allowed-header', 'x-other-allowed-header'),
                 'allowedMethods'      => array('delete', 'get', 'post', 'put'),
@@ -371,7 +397,7 @@ class CorsTest extends PHPUnit_Framework_TestCase
             $options
         );
 
-        return new Cors(new MockApp($responseHeaders), $passedOptions);
+        return new Cors($app, $passedOptions);
     }
 }
 


### PR DESCRIPTION
This PR allows the `Cors` middleware to be instantiated without a `HttpKernelnterface` and adds a `setApp` method for it to be added later.

This allows instantiation outside of the context of building a stack. In our use case middleware are instantiated in factories on a DI container and put together into a stack separately; each instance doesn't know where it will be in the stack when created.

M
