### PR TITLE
Ignore header `Date:` field in unit test.

### DIFF
--- a/test/Asm89/Stack/CorsTest.php
+++ b/test/Asm89/Stack/CorsTest.php
@@ -18,6 +18,10 @@ class CorsTest extends PHPUnit_Framework_TestCase
         $unmodifiedResponse = new Response();
 
         $response = $app->handle(new Request());
+        
+        //The two response are made at different times, ignore the date field.
+        $unmodifiedResponse->headers->date = '';
+        $response->headers->date = '';
 
         $this->assertEquals($unmodifiedResponse->headers, $response->headers);
     }


### PR DESCRIPTION
Stop CI test from failing if the compared responses are made at different times stamps.
