### PR TITLE
OPTIONS response body

### DIFF
--- a/src/Asm89/Stack/CorsService.php
+++ b/src/Asm89/Stack/CorsService.php
@@ -100,6 +100,8 @@ class CorsService
     private function buildPreflightCheckResponse(Request $request)
     {
         $response = new Response();
+        
+        $response->setContent('No Content');
 
         if ($this->options['supportsCredentials']) {
             $response->headers->set('Access-Control-Allow-Credentials', 'true');


### PR DESCRIPTION
Today after composer update my API stopped working, stating that CORS is not enabled. But it was until then and nothing really changed. After a lot of hair pulling I found out, that if I added a response body to the OPTIONS response, everything works fine again!

I do not yet know why the body is necessary or what has changed. Please merge my pull request or add the content in your way. I am using stack-cors as a dependency and would have to fork and maintain the other project aswell for that small fix.
