### PR TITLE
Allow all subdomains as allowed origins

### DIFF
--- a/src/Asm89/Stack/CorsService.php
+++ b/src/Asm89/Stack/CorsService.php
@@ -30,6 +30,13 @@ class CorsService
         // normalize array('*') to true
         if (in_array('*', $options['allowedOrigins'])) {
           $options['allowedOrigins'] = true;
+        } else {
+          // Compile allowed origins into a Regular Expression
+          $origins = array();
+          foreach ($options['allowedOrigins'] as $origin) {
+            $origins[] = str_replace('\\*', '(.+)', preg_quote($origin));
+          }
+          $options['allowedOrigins'] = '/^('.implode('|', $origins).')$/';
         }
         if (in_array('*', $options['allowedHeaders'])) {
           $options['allowedHeaders'] = true;
@@ -162,7 +169,7 @@ class CorsService
         }
         $origin = $request->headers->get('Origin');
 
-        return in_array($origin, $this->options['allowedOrigins']);
+        return preg_match($this->options['allowedOrigins'], $origin);
     }
 
     private function checkMethod(Request $request) {

--- a/test/Asm89/Stack/CorsTest.php
+++ b/test/Asm89/Stack/CorsTest.php
@@ -68,6 +68,22 @@ class CorsTest extends PHPUnit_Framework_TestCase
     /**
      * @test
      */
+    public function it_returns_allow_origin_header_on_allow_subdomain_origin_request()
+    {
+        $app      = $this->createStackedApp(array('allowedOrigins' => array('*.localhost', 'remotehost')));
+        $request  = new Request();
+        $request->headers->set('Origin', 'http://dev.localhost');
+
+        $response = $app->handle($request);
+
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertTrue($response->headers->has('Access-Control-Allow-Origin'));
+        $this->assertEquals('http://dev.localhost', $response->headers->get('Access-Control-Allow-Origin'));
+    }
+
+    /**
+     * @test
+     */
     public function it_returns_allow_headers_header_on_allow_all_headers_request()
     {
         $app     = $this->createStackedApp(array('allowedHeaders' => array('*')));


### PR DESCRIPTION
To ease application deployment et testing, I need to whitelist all the subdomain of a domain.
This is similar to the [express-cors middleware](https://github.com/ybogdanov/express-cors#possible-hosts-specification).

Example: `http://*.github.com`