### PR TITLE
Add branch alias for 0.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,5 +18,10 @@
     },
     "autoload": {
         "psr-0": { "Asm89\\Stack": "src/" }
+    },
+    "extra": {
+        "branch-alias": {
+            "dev-master": "0.2-dev"
+        }
     }
 }


### PR DESCRIPTION
So people can use `0.2@dev` instead of dev-master.
