### PR TITLE
Skip empty Access-Control-Request-Header

### DIFF
--- a/src/Asm89/Stack/CorsService.php
+++ b/src/Asm89/Stack/CorsService.php
@@ -138,7 +138,7 @@ class CorsService
         // if allowedHeaders has been set to true ('*' allow all flag) just skip this check
         if ($this->options['allowedHeaders'] !== true && $request->headers->has('Access-Control-Request-Headers')) {
             $headers        = strtolower($request->headers->get('Access-Control-Request-Headers'));
-            $requestHeaders = explode(',', $headers);
+            $requestHeaders = array_filter(explode(',', $headers));
 
             foreach ($requestHeaders as $header) {
                 if ( ! in_array(trim($header), $this->options['allowedHeaders'])) {

--- a/test/Asm89/Stack/CorsTest.php
+++ b/test/Asm89/Stack/CorsTest.php
@@ -340,6 +340,19 @@ class CorsTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(42, $response->headers->get('Access-Control-Max-Age'));
     }
 
+    /**
+     * @test
+     */
+    public function it_skips_empty_access_control_request_header()
+    {
+        $app     = $this->createStackedApp();
+        $request = $this->createValidPreflightRequest();
+        $request->headers->set('Access-Control-Request-Headers', '');
+        
+        $response = $app->handle($request);
+        $this->assertEquals(200, $response->getStatusCode());
+    }
+
     private function createValidActualRequest()
     {
         $request  = new Request();


### PR DESCRIPTION
It is allowed to make requests without `Access-Control-Request-Header` http header, but when `Access-Control-Request-Header` header is present with empty value, http request doesn't pass preflight request conditions, but should. 
