### PR TITLE
allow a return of access-controll-allow-origin: '*'

### DIFF
--- a/src/Asm89/Stack/CorsService.php
+++ b/src/Asm89/Stack/CorsService.php
@@ -69,7 +69,11 @@ class CorsService
             return $response;
         }
 
-        $response->headers->set('Access-Control-Allow-Origin', $request->headers->get('Origin'));
+        if ($this->options['allowedOrigins'] === true) {
+            $response->headers->set('Access-Control-Allow-Origin', '*');
+        } else {
+            $response->headers->set('Access-Control-Allow-Origin', $request->headers->get('Origin'));
+        }
 
         if ( ! $response->headers->has('Vary')) {
             $response->headers->set('Vary', 'Origin');


### PR DESCRIPTION
Drupal adapter this library with the release of Drupal 8.2.

Currently it's not possible to serve more then 1 domain with Drupal 8.2 even if you configured it to allow '*' because the first response is cached and here we set the allow-origin to the request origin.

Therefor only the request origin of the first request is allowed to access the Drupal instance.

In this pull request i explicitly allow to set the allow-origin be set to '*' if it was set like this.