### PR TITLE
Allow wildcard origin response header

### DIFF
--- a/src/Asm89/Stack/CorsService.php
+++ b/src/Asm89/Stack/CorsService.php
@@ -77,7 +77,10 @@ class CorsService
             return $response;
         }
 
-        $response->headers->set('Access-Control-Allow-Origin', $request->headers->get('Origin'));
+        $allowOrigin = $this->options['allowedOrigins'] === true && !$this->options['supportsCredentials']
+            ? '*'
+            : $request->headers->get('Origin');
+        $response->headers->set('Access-Control-Allow-Origin', $allowOrigin);
 
         if (!$response->headers->has('Vary')) {
             $response->headers->set('Vary', 'Origin');


### PR DESCRIPTION
As discussed in #33, the Origin could allow multiple (or all) origins. When are currently returning the origin which is requested.

This PR would return  `*` when all origins are allowed.

Pros:
 - Explicitly return what is configured
 - Better caching (But should be invalidated because of Origin Vary header?)

Cons:
 - Exposes more info?

Further steps:
 - Could also return the array of origins, when multiple are allowed (but not all). But would perhaps expose origins.
