### PR TITLE
Dev is the default for composer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,6 @@ php:
   - 7.1
   - hhvm
 
-before_script: composer install --dev
+before_script: composer install
 
 script: vendor/bin/phpunit


### PR DESCRIPTION
It would have been deprecated by the authors of Composer, had it not been for it's wide spread usage. (I don't have a reference for that I'm afraid, since I read it ~2 years ago, however the fact that it's a default is easy to prove, by the fact the tests pass)