### PR TITLE
Add preflightheaders method

### DIFF
--- a/src/Asm89/Stack/CorsService.php
+++ b/src/Asm89/Stack/CorsService.php
@@ -98,16 +98,16 @@ class CorsService
 
     public function handlePreflightRequest(Request $request)
     {
+        $response = new Response();
+
+        return $this->addPreflightRequestHeaders($response, $request);
+    }
+
+    public function addPreflightRequestHeaders(Response $response, Request $request)
+    {
         if (true !== $check = $this->checkPreflightRequestConditions($request)) {
             return $check;
         }
-
-        return $this->buildPreflightCheckResponse($request);
-    }
-
-    private function buildPreflightCheckResponse(Request $request)
-    {
-        $response = new Response();
 
         if ($this->options['supportsCredentials']) {
             $response->headers->set('Access-Control-Allow-Credentials', 'true');


### PR DESCRIPTION
In my case with Laravel; Laravel generates an OPTION request consistent with the app itself (eg. 404 in some cases). This makes it easier to add the headers to an existing response, when valid.

Other option could be to add an option $response parameter to `handlePreflightRequest` which defaults to  `new Response`, but that is technically breaking.