### PR TITLE
Add option to match origin with regex patterns

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,12 +26,13 @@ This package can be used as a library or as [stack middleware].
 use Asm89\Stack\CorsService;
 
 $cors = new CorsService(array(
-    'allowedHeaders'      => array('x-allowed-header', 'x-other-allowed-header'),
-    'allowedMethods'      => array('DELETE', 'GET', 'POST', 'PUT'),
-    'allowedOrigins'      => array('localhost'),
-    'exposedHeaders'      => false,
-    'maxAge'              => false,
-    'supportsCredentials' => false,
+    'allowedHeaders'         => array('x-allowed-header', 'x-other-allowed-header'),
+    'allowedMethods'         => array('DELETE', 'GET', 'POST', 'PUT'),
+    'allowedOrigins'         => array('localhost'),
+    'allowedOriginsPatterns' => array('/localhost:\d/'),
+    'exposedHeaders'         => false,
+    'maxAge'                 => false,
+    'supportsCredentials'    => false,
 ));
 
 $cors->addActualRequestHeaders(Response $response, $origin);
@@ -55,6 +56,8 @@ $app = new Cors($app, array(
     'allowedMethods'      => array('DELETE', 'GET', 'POST', 'PUT'),
     // you can use array('*') to allow requests from any origin
     'allowedOrigins'      => array('localhost'),
+    // you can enter regexes that are matched to the origin request header
+    'allowedOriginsPatterns' => array('/localhost:\d/'),
     'exposedHeaders'      => false,
     'maxAge'              => false,
     'supportsCredentials' => false,

--- a/README.md
+++ b/README.md
@@ -18,6 +18,24 @@ This package can be used as a library or as [stack middleware].
 
 [stack middleware]: http://stackphp.com/
 
+### Options
+
+| Option                 | Description                                                | Default value |
+|------------------------|------------------------------------------------------------|---------------|
+| allowedMethods         | Matches the request method.                                | `array()`     |
+| allowedOrigins         | Matches the request origin.                                | `array()`     |
+| allowedOriginsPatterns | Matches the request origin with `preg_match`.              | `array()`  |
+| allowedHeaders         | Sets the Access-Control-Allow-Headers response header.     | `array()`     |
+| exposedHeaders         | Sets the Access-Control-Expose-Headers response header.    | `false`       |
+| maxAge                 | Sets the Access-Control-Max-Age response header.           | `false`       |
+| supportsCredentials    | Sets the Access-Control-Allow-Credentials header.          | `false`       |
+
+The _allowedMethods_ and _allowedHeaders_ options are case-insensitive.
+
+You don't need to provide both _allowedOrigins_ and _allowedOriginsPatterns_. If one of the strings passed matches, it is considered a valid origin.
+
+If `array('*')` is provided to _allowedMethods_, _allowedOrigins_ or _allowedHeaders_ all methods / origins / headers are allowed.
+
 ### Example: using the library
 
 ```php

--- a/src/Asm89/Stack/Cors.php
+++ b/src/Asm89/Stack/Cors.php
@@ -28,12 +28,13 @@ class Cors implements HttpKernelInterface
     private $cors;
 
     private $defaultOptions = array(
-        'allowedHeaders'      => array(),
-        'allowedMethods'      => array(),
-        'allowedOrigins'      => array(),
-        'exposedHeaders'      => false,
-        'maxAge'              => false,
-        'supportsCredentials' => false,
+        'allowedHeaders'         => array(),
+        'allowedMethods'         => array(),
+        'allowedOrigins'         => array(),
+        'allowedOriginsPatterns' => array(),
+        'exposedHeaders'         => false,
+        'maxAge'                 => false,
+        'supportsCredentials'    => false,
     );
 
     public function __construct(HttpKernelInterface $app, array $options = array())

--- a/src/Asm89/Stack/CorsService.php
+++ b/src/Asm89/Stack/CorsService.php
@@ -28,6 +28,7 @@ class CorsService
     {
         $options += array(
             'allowedOrigins' => array(),
+            'allowedOriginsPatterns' => array(),
             'supportsCredentials' => false,
             'allowedHeaders' => array(),
             'exposedHeaders' => array(),
@@ -176,7 +177,17 @@ class CorsService
         }
         $origin = $request->headers->get('Origin');
 
-        return in_array($origin, $this->options['allowedOrigins']);
+        if (in_array($origin, $this->options['allowedOrigins'])) {
+            return true;
+        }
+
+        foreach ($this->options['allowedOriginsPatterns'] as $pattern) {
+            if (preg_match($pattern, $origin)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     private function checkMethod(Request $request)

--- a/test/Asm89/Stack/CorsTest.php
+++ b/test/Asm89/Stack/CorsTest.php
@@ -209,6 +209,23 @@ class CorsTest extends PHPUnit_Framework_TestCase
     /**
      * @test
      */
+    public function it_returns_access_control_headers_on_cors_request_with_pattern_origin()
+    {
+        $app = $this->createStackedApp(array(
+          'allowedOrigins' => array(),
+          'allowedOriginsPatterns' => array('/l(o|0)calh(o|0)st/')
+        ));
+        $request  = $this->createValidActualRequest();
+
+        $response = $app->handle($request);
+
+        $this->assertTrue($response->headers->has('Access-Control-Allow-Origin'));
+        $this->assertEquals('localhost', $response->headers->get('Access-Control-Allow-Origin'));
+    }
+
+    /**
+     * @test
+     */
     public function it_returns_access_control_headers_on_valid_preflight_request()
     {
         $app     = $this->createStackedApp();
@@ -240,6 +257,24 @@ class CorsTest extends PHPUnit_Framework_TestCase
     {
         $passedOptions = array(
           'allowedOrigins' => array('notlocalhost'),
+        );
+
+        $service  = new CorsService($passedOptions);
+        $request  = $this->createValidActualRequest();
+        $response = new Response();
+        $service->addActualRequestHeaders($response, $request);
+
+        $this->assertEquals($response, new Response());
+    }
+
+    /**
+     * @test
+     */
+    public function it_does_not_modify_request_with_pattern_origin_not_allowed()
+    {
+        $passedOptions = array(
+            'allowedOrigins' => array(),
+            'allowedOriginsPatterns' => array('/l\dcalh\dst/')
         );
 
         $service  = new CorsService($passedOptions);


### PR DESCRIPTION
This adds an option `allowedOriginsPatterns` that expects an array of regex strings. Each string is passed to `preg_match` to determine if the origin is allowed.

It is backwards compatible, the allowedOrigins still works.

I have also added two tests to make sure the option works as expected.

It is more lightweight then pull request #42, where also the use of regexes was discussed.