### PR TITLE
Allow "Access-Control-Allow-Origin: *" to avoid issues with Varnish cache

### DIFF
--- a/src/Asm89/Stack/CorsService.php
+++ b/src/Asm89/Stack/CorsService.php
@@ -78,7 +78,18 @@ class CorsService
             return $response;
         }
 
-        $response->headers->set('Access-Control-Allow-Origin', $request->headers->get('Origin'));
+        /*
+         * If 'allowedOrigins' is set to '*' and we don't need to support credentials, allow all origins.
+         *
+         * From MDN documentation (https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Origin):
+         * "For requests without credentials, the server may specify "*" as a wildcard, thereby allowing any origin to access the resource."
+         *
+         */
+        if ($this->options['allowedOrigins'] && !$this->options['supportsCredentials']) {
+            $response->headers->set('Access-Control-Allow-Origin', '*');
+        } else {
+            $response->headers->set('Access-Control-Allow-Origin', $request->headers->get('Origin'));
+        }
 
         if (!$response->headers->has('Vary')) {
             $response->headers->set('Vary', 'Origin');
@@ -114,7 +125,18 @@ class CorsService
             $response->headers->set('Access-Control-Allow-Credentials', 'true');
         }
 
-        $response->headers->set('Access-Control-Allow-Origin', $request->headers->get('Origin'));
+        /*
+         * If 'allowedOrigins' is set to '*' and we don't need to support credentials, allow all origins.
+         *
+         * From MDN documentation (https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Origin):
+         * "For requests without credentials, the server may specify "*" as a wildcard, thereby allowing any origin to access the resource."
+         *
+         */
+        if ($this->options['allowedOrigins'] && !$this->options['supportsCredentials']) {
+            $response->headers->set('Access-Control-Allow-Origin', '*');
+        } else {
+            $response->headers->set('Access-Control-Allow-Origin', $request->headers->get('Origin'));
+        }
 
         if ($this->options['maxAge']) {
             $response->headers->set('Access-Control-Max-Age', $this->options['maxAge']);


### PR DESCRIPTION
Hi,

I recently implemented Varnish caching proxy in front of some API servers using this package to handle CORS headers. I configured Varnish to cache pre-flight OPTIONS responses. 

Today I realised that the 'Origin' from the request was being set as the value for the 'Access-Control-Allow-Origin' response header. If a request is made from a non-standard origin, e.g. a testing domain, the OPTIONS response will be cached with an incorrect value. Ideally, I just need 'Access-Control-Allow-Origin' to return '*' as configured in the config file.

This pull request adds the ability to return `'Access-Control-Allow-Origin: *'` when the config for `'allowedOrigins'` is set to `["*"]` and `'supportsCredentials'` is `false`.

This conforms with the documentation on the MDN: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Origin