### PR TITLE
Replaced bad request responses with exceptions.

### DIFF
--- a/src/Asm89/Stack/CorsService.php
+++ b/src/Asm89/Stack/CorsService.php
@@ -11,6 +11,9 @@
 
 namespace Asm89\Stack;
 
+use Asm89\Stack\Exception\HeaderNotAllowedException;
+use Asm89\Stack\Exception\MethodNotAllowedException;
+use Asm89\Stack\Exception\OriginNotAllowedException;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -138,11 +141,11 @@ class CorsService
     private function checkPreflightRequestConditions(Request $request)
     {
         if (!$this->checkOrigin($request)) {
-            return $this->createBadRequestResponse(403, 'Origin not allowed');
+            throw new OriginNotAllowedException();
         }
 
         if (!$this->checkMethod($request)) {
-            return $this->createBadRequestResponse(405, 'Method not allowed');
+            throw new MethodNotAllowedException($this->options['allowedMethods']);
         }
 
         $requestHeaders = array();
@@ -153,17 +156,12 @@ class CorsService
 
             foreach ($requestHeaders as $header) {
                 if (!in_array(trim($header), $this->options['allowedHeaders'])) {
-                    return $this->createBadRequestResponse(403, 'Header not allowed');
+                    throw new HeaderNotAllowedException();
                 }
             }
         }
 
         return true;
-    }
-
-    private function createBadRequestResponse($code, $reason = '')
-    {
-        return new Response($reason, $code);
     }
 
     private function isSameHost(Request $request)

--- a/src/Asm89/Stack/Exception/HeaderNotAllowedException.php
+++ b/src/Asm89/Stack/Exception/HeaderNotAllowedException.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of asm89/stack-cors.
+ *
+ * (c) Alexander <iam.asm89@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Asm89\Stack\Exception;
+
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
+
+class HeaderNotAllowedException extends AccessDeniedHttpException
+{
+    public function __construct()
+    {
+        parent::__construct('Header not allowed');
+    }
+}

--- a/src/Asm89/Stack/Exception/MethodNotAllowedException.php
+++ b/src/Asm89/Stack/Exception/MethodNotAllowedException.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of asm89/stack-cors.
+ *
+ * (c) Alexander <iam.asm89@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Asm89\Stack\Exception;
+
+use Symfony\Component\HttpKernel\Exception\MethodNotAllowedHttpException;
+
+class MethodNotAllowedException extends MethodNotAllowedHttpException
+{
+    /**
+     * Constructor.
+     *
+     * @param array      $allow    An array of allowed methods
+     */
+    public function __construct(array $allow)
+    {
+        parent::__construct($allow, 'Method not allowed');
+    }
+}

--- a/src/Asm89/Stack/Exception/OriginNotAllowedException.php
+++ b/src/Asm89/Stack/Exception/OriginNotAllowedException.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of asm89/stack-cors.
+ *
+ * (c) Alexander <iam.asm89@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Asm89\Stack\Exception;
+
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
+
+class OriginNotAllowedException extends AccessDeniedHttpException
+{
+    public function __construct()
+    {
+        parent::__construct('Origin not allowed');
+    }
+}

--- a/src/Asm89/Stack/Exception/RequestNotAllowedException.php
+++ b/src/Asm89/Stack/Exception/RequestNotAllowedException.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of asm89/stack-cors.
+ *
+ * (c) Alexander <iam.asm89@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Asm89\Stack\Exception;
+
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
+
+class RequestNotAllowedException extends AccessDeniedHttpException
+{
+    public function __construct()
+    {
+        parent::__construct('Not allowed.');
+    }
+}


### PR DESCRIPTION
I'm thinking throwing exceptions instead of returning responses would make more sense in the service.
In the kernel decorator the exception gets caught and converted to an exception if desired.

This is braking change and would require a new major version since some packages might use the CorsService only.

There is another change. The MethodNotAllowedException will let the client know what methods are allowed. Not sure if this is desired or allowed according to the standard.

Let me know what you think.
Maybe the exceptions should have more arguments.