### PR TITLE
Fixed travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,25 +1,26 @@
 language: php
 
-php:
-  - 7.1
-  - 7.2
-  - 7.3
-
-# This triggers builds to run on the new TravisCI infrastructure.
-# See: http://docs.travis-ci.com/user/workers/container-based-infrastructure/
-sudo: false
-
-## Cache composer
-cache:
-  directories:
-    - $HOME/.composer/cache
-
 matrix:
   include:
-    - php: 7.1
+    - php: 5.5.9
+      dist: trusty
       env: 'COMPOSER_FLAGS="--prefer-stable --prefer-lowest"'
+    - php: 5.5
+      dist: trusty
+    - php: 5.6
+      dist: xenial
+    - php: 7.0
+      dist: xenial
+    - php: 7.1
+      dist: bionic
+    - php: 7.2
+      dist: bionic
+    - php: 7.3
+      dist: bionic
+    - php: 7.4
+      dist: bionic
 
-before_script:
+install:
   - travis_retry composer update ${COMPOSER_FLAGS}
 
 script:


### PR DESCRIPTION
1. It's claimed that PHP 5.5.9 is supported in the composer.json file, yet for some reason, it was intentionally deleted from the CI?
2. Fetching and storing the composer cache is as slow as just running composer without the cache.