### PR TITLE
Make distinction between 0 or false for maxAge

### DIFF
--- a/src/Asm89/Stack/CorsService.php
+++ b/src/Asm89/Stack/CorsService.php
@@ -116,7 +116,7 @@ class CorsService
 
         $response->headers->set('Access-Control-Allow-Origin', $request->headers->get('Origin'));
 
-        if ($this->options['maxAge']) {
+        if ($this->options['maxAge'] !== false) {
             $response->headers->set('Access-Control-Max-Age', $this->options['maxAge']);
         }
 

--- a/src/Asm89/Stack/CorsService.php
+++ b/src/Asm89/Stack/CorsService.php
@@ -116,7 +116,7 @@ class CorsService
 
         $response->headers->set('Access-Control-Allow-Origin', $request->headers->get('Origin'));
 
-        if ($this->options['maxAge'] !== false) {
+        if ($this->options['maxAge'] !== null) {
             $response->headers->set('Access-Control-Max-Age', $this->options['maxAge']);
         }
 

--- a/test/Asm89/Stack/CorsTest.php
+++ b/test/Asm89/Stack/CorsTest.php
@@ -405,6 +405,33 @@ class CorsTest extends PHPUnit_Framework_TestCase
     /**
      * @test
      */
+    public function it_sets_max_age_when_zero()
+    {
+        $app     = $this->createStackedApp(array('maxAge' => 0));
+        $request = $this->createValidPreflightRequest();
+
+        $response = $app->handle($request);
+
+        $this->assertTrue($response->headers->has('Access-Control-Max-Age'));
+        $this->assertEquals(0, $response->headers->get('Access-Control-Max-Age'));
+    }
+
+    /**
+     * @test
+     */
+    public function it_doesnt_set_max_age_when_false()
+    {
+        $app     = $this->createStackedApp(array('maxAge' => false));
+        $request = $this->createValidPreflightRequest();
+
+        $response = $app->handle($request);
+
+        $this->assertFalse($response->headers->has('Access-Control-Max-Age'));
+    }
+
+    /**
+     * @test
+     */
     public function it_skips_empty_access_control_request_header()
     {
         $app     = $this->createStackedApp();

--- a/test/Asm89/Stack/CorsTest.php
+++ b/test/Asm89/Stack/CorsTest.php
@@ -421,7 +421,7 @@ class CorsTest extends PHPUnit_Framework_TestCase
      */
     public function it_doesnt_set_max_age_when_false()
     {
-        $app     = $this->createStackedApp(array('maxAge' => false));
+        $app     = $this->createStackedApp(array('maxAge' => null));
         $request = $this->createValidPreflightRequest();
 
         $response = $app->handle($request);


### PR DESCRIPTION
Right now, when the maxAge is 0 or false, it's not set (https://github.com/asm89/stack-cors/blob/82ede75f64bd2801773d7179d63468dcf7cad526/src/Asm89/Stack/CorsService.php#L119-L121)

MDN webdocs state here that Chrome uses 5 seconds by default:
https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Max-Age
-1 is also allowed to disabled caching.

Should we make a distinction between 0 and false? Should false be interpreted as -1, or not setting it? Should 0 set the header to 0 (which is now impossible)?

The defaults were different on 2 locations (which is now the same as of https://github.com/asm89/stack-cors/pull/61/), so it seems the expected behaviour was to handle them the same. 

I suggest to handle them 'as-is' when it's actually an integer (or numeric at least), and skip the header only when actually false.

So is this technically a BC break, or a fix of intended behaviour (if the assumption before was that NOT setting it also implied an age of 0)