### PR TITLE
Change Preflight HTTP status code from 204 to 200

### DIFF
--- a/src/Asm89/Stack/CorsService.php
+++ b/src/Asm89/Stack/CorsService.php
@@ -130,7 +130,7 @@ class CorsService
             : implode(', ', $this->options['allowedHeaders']);
         $response->headers->set('Access-Control-Allow-Headers', $allowHeaders);
 
-        $response->setStatusCode(204);
+        $response->setStatusCode(200);
 
         return $response;
     }

--- a/test/Asm89/Stack/CorsTest.php
+++ b/test/Asm89/Stack/CorsTest.php
@@ -103,7 +103,7 @@ class CorsTest extends PHPUnit_Framework_TestCase
 
         $response = $app->handle($request);
 
-        $this->assertEquals(204, $response->getStatusCode());
+        $this->assertEquals(200, $response->getStatusCode());
         $this->assertEquals('FOO, BAR', $response->headers->get('Access-Control-Allow-Headers'));
     }
 
@@ -354,7 +354,7 @@ class CorsTest extends PHPUnit_Framework_TestCase
 
         $response = $app->handle($request);
 
-        $this->assertEquals(204, $response->getStatusCode());
+        $this->assertEquals(200, $response->getStatusCode());
 
         $this->assertTrue($response->headers->has('Access-Control-Allow-Headers'));
         // the response will have the "allowedHeaders" value passed to Cors rather than the request one
@@ -412,7 +412,7 @@ class CorsTest extends PHPUnit_Framework_TestCase
         $request->headers->set('Access-Control-Request-Headers', '');
 
         $response = $app->handle($request);
-        $this->assertEquals(204, $response->getStatusCode());
+        $this->assertEquals(200, $response->getStatusCode());
     }
 
     private function createValidActualRequest()


### PR DESCRIPTION
Firefox started rejecting CORS requests if 204 is received in the preflight.