### PR TITLE
Remove CORS check in actual request, fixes #65

### DIFF
--- a/src/Asm89/Stack/Cors.php
+++ b/src/Asm89/Stack/Cors.php
@@ -53,10 +53,6 @@ class Cors implements HttpKernelInterface
             return $this->cors->handlePreflightRequest($request);
         }
 
-        if (!$this->cors->isActualRequestAllowed($request)) {
-            return new Response('Not allowed.', 403);
-        }
-
         $response = $this->app->handle($request, $type, $catch);
 
         return $this->cors->addActualRequestHeaders($response, $request);

--- a/src/Asm89/Stack/CorsService.php
+++ b/src/Asm89/Stack/CorsService.php
@@ -55,6 +55,9 @@ class CorsService
         return $options;
     }
 
+    /**
+     * @deprecated since 1.4, will be removed in 2.x
+     */
     public function isActualRequestAllowed(Request $request)
     {
         return $this->checkOrigin($request);
@@ -99,10 +102,6 @@ class CorsService
 
     public function handlePreflightRequest(Request $request)
     {
-        if (true !== $check = $this->checkPreflightRequestConditions($request)) {
-            return $check;
-        }
-
         return $this->buildPreflightCheckResponse($request);
     }
 
@@ -135,37 +134,6 @@ class CorsService
         return $response;
     }
 
-    private function checkPreflightRequestConditions(Request $request)
-    {
-        if (!$this->checkOrigin($request)) {
-            return $this->createBadRequestResponse(403, 'Origin not allowed');
-        }
-
-        if (!$this->checkMethod($request)) {
-            return $this->createBadRequestResponse(405, 'Method not allowed');
-        }
-
-        $requestHeaders = array();
-        // if allowedHeaders has been set to true ('*' allow all flag) just skip this check
-        if ($this->options['allowedHeaders'] !== true && $request->headers->has('Access-Control-Request-Headers')) {
-            $headers        = strtolower($request->headers->get('Access-Control-Request-Headers'));
-            $requestHeaders = array_filter(explode(',', $headers));
-
-            foreach ($requestHeaders as $header) {
-                if (!in_array(trim($header), $this->options['allowedHeaders'])) {
-                    return $this->createBadRequestResponse(403, 'Header not allowed');
-                }
-            }
-        }
-
-        return true;
-    }
-
-    private function createBadRequestResponse($code, $reason = '')
-    {
-        return new Response($reason, $code);
-    }
-
     private function isSameHost(Request $request)
     {
         return $request->headers->get('Origin') === $request->getSchemeAndHttpHost();
@@ -190,16 +158,5 @@ class CorsService
         }
 
         return false;
-    }
-
-    private function checkMethod(Request $request)
-    {
-        if ($this->options['allowedMethods'] === true) {
-            // allow all '*' flag
-            return true;
-        }
-
-        $requestMethod = strtoupper($request->headers->get('Access-Control-Request-Method'));
-        return in_array($requestMethod, $this->options['allowedMethods']);
     }
 }

--- a/test/Asm89/Stack/CorsTest.php
+++ b/test/Asm89/Stack/CorsTest.php
@@ -227,19 +227,6 @@ class CorsTest extends PHPUnit_Framework_TestCase
     /**
      * @test
      */
-    public function it_returns_403_on_valid_preflight_request_with_origin_not_allowed()
-    {
-        $app     = $this->createStackedApp(array('allowedOrigins' => array('notlocalhost')));
-        $request = $this->createValidPreflightRequest();
-
-        $response = $app->handle($request);
-
-        $this->assertEquals(403, $response->getStatusCode());
-    }
-
-    /**
-     * @test
-     */
     public function it_does_not_modify_request_with_origin_not_allowed()
     {
         $passedOptions = array(
@@ -275,19 +262,6 @@ class CorsTest extends PHPUnit_Framework_TestCase
     /**
      * @test
      */
-    public function it_returns_405_on_valid_preflight_request_with_method_not_allowed()
-    {
-        $app     = $this->createStackedApp(array('allowedMethods' => array('put')));
-        $request = $this->createValidPreflightRequest();
-
-        $response = $app->handle($request);
-
-        $this->assertEquals(405, $response->getStatusCode());
-    }
-
-    /**
-     * @test
-     */
     public function it_allow_methods_on_valid_preflight_request()
     {
         $app     = $this->createStackedApp(array('allowedMethods' => array('get', 'put')));
@@ -313,20 +287,6 @@ class CorsTest extends PHPUnit_Framework_TestCase
         $this->assertTrue($response->headers->has('Access-Control-Allow-Methods'));
         // it will return the Access-Control-Request-Method pass in the request
         $this->assertEquals('GET', $response->headers->get('Access-Control-Allow-Methods'));
-    }
-
-    /**
-     * @test
-     */
-    public function it_returns_403_on_valid_preflight_request_with_one_of_the_requested_headers_not_allowed()
-    {
-        $app     = $this->createStackedApp();
-        $request = $this->createValidPreflightRequest();
-        $request->headers->set('Access-Control-Request-Headers', 'x-not-allowed-header');
-
-        $response = $app->handle($request);
-
-        $this->assertEquals(403, $response->getStatusCode());
     }
 
     /**

--- a/test/Asm89/Stack/CorsTest.php
+++ b/test/Asm89/Stack/CorsTest.php
@@ -52,19 +52,6 @@ class CorsTest extends PHPUnit_Framework_TestCase
     /**
      * @test
      */
-    public function it_returns_403_on_valid_actual_request_with_origin_not_allowed()
-    {
-        $app      = $this->createStackedApp(array('allowedOrigins' => array('notlocalhost')));
-        $request  = $this->createValidActualRequest();
-
-        $response = $app->handle($request);
-
-        $this->assertEquals(403, $response->getStatusCode());
-    }
-
-    /**
-     * @test
-     */
     public function it_returns_allow_origin_header_on_valid_actual_request()
     {
         $app      = $this->createStackedApp();


### PR DESCRIPTION
Remove the actual check, let the browser take care of this. Don't make it harder than it already is and it provides a false sense of security (CORS is not for restricting access, as headers can be forged) Fixes #65