### PR TITLE
Make responses cacheable by only using dynamic origins when required

### DIFF
--- a/src/Asm89/Stack/Cors.php
+++ b/src/Asm89/Stack/Cors.php
@@ -45,10 +45,6 @@ class Cors implements HttpKernelInterface
 
     public function handle(Request $request, $type = HttpKernelInterface::MASTER_REQUEST, $catch = true)
     {
-        if (!$this->cors->isCorsRequest($request)) {
-            return $this->app->handle($request, $type, $catch);
-        }
-
         if ($this->cors->isPreflightRequest($request)) {
             return $this->cors->handlePreflightRequest($request);
         }

--- a/src/Asm89/Stack/Cors.php
+++ b/src/Asm89/Stack/Cors.php
@@ -45,6 +45,10 @@ class Cors implements HttpKernelInterface
 
     public function handle(Request $request, $type = HttpKernelInterface::MASTER_REQUEST, $catch = true)
     {
+        if (!$this->cors->isCorsRequest($request)) {
+            return $this->app->handle($request, $type, $catch);
+        }
+
         if ($this->cors->isPreflightRequest($request)) {
             return $this->cors->handlePreflightRequest($request);
         }

--- a/src/Asm89/Stack/Cors.php
+++ b/src/Asm89/Stack/Cors.php
@@ -53,10 +53,6 @@ class Cors implements HttpKernelInterface
             return $this->cors->handlePreflightRequest($request);
         }
 
-        if (!$this->cors->isActualRequestAllowed($request)) {
-            return new Response('Not allowed.', 403);
-        }
-
         $response = $this->app->handle($request, $type, $catch);
 
         return $this->cors->addActualRequestHeaders($response, $request);

--- a/src/Asm89/Stack/CorsService.php
+++ b/src/Asm89/Stack/CorsService.php
@@ -11,7 +11,6 @@
 
 namespace Asm89\Stack;
 
-use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 

--- a/src/Asm89/Stack/CorsService.php
+++ b/src/Asm89/Stack/CorsService.php
@@ -135,9 +135,7 @@ class CorsService
 
         if ($this->options['allowedMethods'] === true) {
             if ($this->options['supportsCredentials']) {
-                $allowMethods = strtoupper($request->headers->get('Access-Control-Request-Method'));
-                $this->varyHeader('Access-Control-Request-Method');
-                $maxAge = -1;
+                $allowMethods = 'GET, HEAD, PUT, PATCH, POST, DELETE';
             } else {
                 $allowMethods = '*';
             }

--- a/src/Asm89/Stack/CorsService.php
+++ b/src/Asm89/Stack/CorsService.php
@@ -131,14 +131,13 @@ class CorsService
 
         $this->addAllowedOrigin($response, $request);
 
-        if ($this->options['maxAge'] !== null) {
-            $response->headers->set('Access-Control-Max-Age', $this->options['maxAge']);
-        }
+        $maxAge = $this->options['maxAge'];
 
         if ($this->options['allowedMethods'] === true) {
             if ($this->options['supportsCredentials']) {
                 $allowMethods = strtoupper($request->headers->get('Access-Control-Request-Method'));
                 $this->varyHeader('Access-Control-Request-Method');
+                $maxAge = -1;
             } else {
                 $allowMethods = '*';
             }
@@ -151,6 +150,7 @@ class CorsService
             if ($this->options['supportsCredentials']) {
                 $allowHeaders = strtoupper($request->headers->get('Access-Control-Request-Headers'));
                 $this->varyHeader('Access-Control-Request-Headers');
+                $maxAge = -1;
             } else {
                 $allowHeaders = '*';
             }
@@ -158,6 +158,10 @@ class CorsService
             $allowHeaders = implode(', ', $this->options['allowedHeaders']);
         }
         $response->headers->set('Access-Control-Allow-Headers', $allowHeaders);
+
+        if ($maxAge !== null) {
+            $response->headers->set('Access-Control-Max-Age', $maxAge);
+        }
 
         $response->setStatusCode(204);
 

--- a/src/Asm89/Stack/CorsService.php
+++ b/src/Asm89/Stack/CorsService.php
@@ -37,7 +37,7 @@ class CorsService
         );
 
         // normalize true to array('*')
-        if ($options['allowedOrigins'] === true ) {
+        if ($options['allowedOrigins'] === true) {
             $options['allowedOrigins'] = ['*'];
         }
         if (in_array('*', $options['allowedHeaders'])) {

--- a/src/Asm89/Stack/CorsService.php
+++ b/src/Asm89/Stack/CorsService.php
@@ -131,8 +131,6 @@ class CorsService
 
         $this->addAllowedOrigin($response, $request);
 
-        $maxAge = $this->options['maxAge'];
-
         if ($this->options['allowedMethods'] === true) {
             if ($this->options['supportsCredentials']) {
                 $allowMethods = 'GET, HEAD, PUT, PATCH, POST, DELETE';
@@ -148,7 +146,6 @@ class CorsService
             if ($this->options['supportsCredentials']) {
                 $allowHeaders = strtoupper($request->headers->get('Access-Control-Request-Headers'));
                 $this->varyHeader('Access-Control-Request-Headers');
-                $maxAge = -1;
             } else {
                 $allowHeaders = '*';
             }
@@ -157,8 +154,8 @@ class CorsService
         }
         $response->headers->set('Access-Control-Allow-Headers', $allowHeaders);
 
-        if ($maxAge !== null) {
-            $response->headers->set('Access-Control-Max-Age', $maxAge);
+        if ($this->options['maxAge'] !== null) {
+            $response->headers->set('Access-Control-Max-Age', (int) $this->options['maxAge']);
         }
 
         $response->setStatusCode(204);

--- a/src/Asm89/Stack/CorsService.php
+++ b/src/Asm89/Stack/CorsService.php
@@ -55,6 +55,14 @@ class CorsService
         return $options;
     }
 
+    /**
+     * @deprecated use isOriginAllowed
+     */
+    public function isActualRequestAllowed(Request $request)
+    {
+        return $this->isOriginAllowed($request);
+    }
+
     public function isCorsRequest(Request $request)
     {
         return $request->headers->has('Origin') && !$this->isSameHost($request);
@@ -91,18 +99,14 @@ class CorsService
         return $response;
     }
 
-    /**
-     * @deprecated use isOriginAllowed
-     */
-    public function isActualRequestAllowed(Request $request)
-    {
-        return $this->isOriginAllowed($request);
-    }
-
     public function isOriginAllowed(Request $request)
     {
         if ($this->options['allowedOrigins'] === true) {
             return true;
+        }
+
+        if (!$request->headers->has('Origin')) {
+            return false;
         }
 
         $origin = $request->headers->get('Origin');

--- a/src/Asm89/Stack/CorsService.php
+++ b/src/Asm89/Stack/CorsService.php
@@ -188,7 +188,8 @@ class CorsService
         $response->headers->set('Access-Control-Allow-Headers', $allowHeaders);
     }
 
-    private function configureAllowCredentials(Response $response, Request $request){
+    private function configureAllowCredentials(Response $response, Request $request)
+    {
         if ($this->options['supportsCredentials']) {
             $response->headers->set('Access-Control-Allow-Credentials', 'true');
         }
@@ -201,7 +202,8 @@ class CorsService
         }
     }
 
-    private function configureMaxAge(Response $response, Request $request){
+    private function configureMaxAge(Response $response, Request $request)
+    {
         if ($this->options['maxAge'] !== null) {
             $response->headers->set('Access-Control-Max-Age', (int) $this->options['maxAge']);
         }

--- a/src/Asm89/Stack/CorsService.php
+++ b/src/Asm89/Stack/CorsService.php
@@ -162,7 +162,8 @@ class CorsService
     {
         if ($this->options['allowedMethods'] === true) {
             if ($this->options['supportsCredentials']) {
-                $allowMethods = 'GET, HEAD, PUT, PATCH, POST, DELETE';
+                $allowMethods = strtoupper($request->headers->get('Access-Control-Request-Method'));
+                $this->varyHeader($response, 'Access-Control-Request-Method');
             } else {
                 $allowMethods = '*';
             }
@@ -178,7 +179,7 @@ class CorsService
         if ($this->options['allowedHeaders'] === true) {
             if ($this->options['supportsCredentials']) {
                 $allowHeaders = strtoupper($request->headers->get('Access-Control-Request-Headers'));
-                $this->varyHeader('Access-Control-Request-Headers');
+                $this->varyHeader($response, 'Access-Control-Request-Headers');
             } else {
                 $allowHeaders = '*';
             }

--- a/test/Asm89/Stack/CorsTest.php
+++ b/test/Asm89/Stack/CorsTest.php
@@ -76,7 +76,7 @@ class CorsTest extends PHPUnit_Framework_TestCase
 
         $this->assertEquals(200, $response->getStatusCode());
         $this->assertTrue($response->headers->has('Access-Control-Allow-Origin'));
-        $this->assertEquals('http://localhost', $response->headers->get('Access-Control-Allow-Origin'));
+        $this->assertEquals('*', $response->headers->get('Access-Control-Allow-Origin'));
     }
 
     /**
@@ -92,19 +92,6 @@ class CorsTest extends PHPUnit_Framework_TestCase
 
         $this->assertEquals(204, $response->getStatusCode());
         $this->assertEquals('FOO, BAR', $response->headers->get('Access-Control-Allow-Headers'));
-    }
-
-    /**
-     * @test
-     */
-    public function it_does_not_return_allow_origin_header_on_valid_actual_request_with_origin_not_allowed()
-    {
-        $app      = $this->createStackedApp(array('allowedOrigins' => array('notlocalhost')));
-        $request  = $this->createValidActualRequest();
-
-        $response = $app->handle($request);
-
-        $this->assertFalse($response->headers->has('Access-Control-Allow-Origin'));
     }
 
     /**
@@ -150,11 +137,12 @@ class CorsTest extends PHPUnit_Framework_TestCase
 
     /**
      * @test
-     * @see http://www.w3.org/TR/cors/index.html#resource-implementation
      */
-    public function it_adds_a_vary_header()
+    public function it_adds_a_vary_header_when_supports_credentials()
     {
-        $app      = $this->createStackedApp();
+        $app      = $this->createStackedApp(array(
+            'supportsCredentials' => true,
+        ));
         $request  = $this->createValidActualRequest();
 
         $response = $app->handle($request);
@@ -165,11 +153,49 @@ class CorsTest extends PHPUnit_Framework_TestCase
 
     /**
      * @test
+     */
+    public function it_adds_a_vary_header_when_has_origin_patterns()
+    {
+        $app      = $this->createStackedApp(array(
+            'allowedOriginsPatterns' => array('/l(o|0)calh(o|0)st/')
+        ));
+        $request  = $this->createValidActualRequest();
+
+        $response = $app->handle($request);
+
+        $this->assertTrue($response->headers->has('Vary'));
+        $this->assertEquals('Origin', $response->headers->get('Vary'));
+    }
+
+    /**
+     * @test
+     */
+    public function it_doesnt_add_a_vary_header_when_simple_origins()
+    {
+        $app      = $this->createStackedApp(array(
+            'allowedOrigins' => array('*', 'http://localhost')
+        ));
+        $request  = $this->createValidActualRequest();
+
+        $response = $app->handle($request);
+
+        $this->assertFalse($response->headers->has('Vary'));
+    }
+
+    /**
+     * @test
      * @see http://www.w3.org/TR/cors/index.html#resource-implementation
      */
     public function it_appends_an_existing_vary_header()
     {
-        $app      = $this->createStackedApp(array(), array('Vary' => 'Content-Type'));
+        $app      = $this->createStackedApp(
+            array(
+                'supportsCredentials' => true,
+            ),
+            array(
+                'Vary' => 'Content-Type'
+            )
+        );
         $request  = $this->createValidActualRequest();
 
         $response = $app->handle($request);
@@ -208,6 +234,8 @@ class CorsTest extends PHPUnit_Framework_TestCase
 
         $this->assertTrue($response->headers->has('Access-Control-Allow-Origin'));
         $this->assertEquals('localhost', $response->headers->get('Access-Control-Allow-Origin'));
+        $this->assertTrue($response->headers->has('Vary'));
+        $this->assertEquals('Origin', $response->headers->get('Vary'));
     }
 
     /**
@@ -240,7 +268,7 @@ class CorsTest extends PHPUnit_Framework_TestCase
     /**
      * @test
      */
-    public function it_does_not_modify_request_with_origin_not_allowed()
+    public function it_does_not_allow_request_with_origin_not_allowed()
     {
         $passedOptions = array(
           'allowedOrigins' => array('notlocalhost'),
@@ -251,7 +279,7 @@ class CorsTest extends PHPUnit_Framework_TestCase
         $response = new Response();
         $service->addActualRequestHeaders($response, $request);
 
-        $this->assertEquals($response, new Response());
+        $this->assertNotEquals($request->headers->get('Origin'), $response->headers->get('Access-Control-Allow-Origin'));
     }
 
     /**
@@ -269,7 +297,7 @@ class CorsTest extends PHPUnit_Framework_TestCase
         $response = new Response();
         $service->addActualRequestHeaders($response, $request);
 
-        $this->assertEquals($response, new Response());
+        $this->assertNotEquals($request->headers->get('Origin'), $response->headers->get('Access-Control-Allow-Origin'));
     }
 
     /**

--- a/test/Asm89/Stack/CorsTest.php
+++ b/test/Asm89/Stack/CorsTest.php
@@ -21,37 +21,6 @@ class CorsTest extends PHPUnit_Framework_TestCase
     /**
      * @test
      */
-    public function it_does_not_modify_on_a_request_without_origin()
-    {
-        $app                = $this->createStackedApp();
-        $unmodifiedResponse = new Response();
-
-        $response = $app->handle(new Request());
-
-        $this->assertEquals($unmodifiedResponse->headers, $response->headers);
-    }
-
-    /**
-     * @test
-     */
-    public function it_does_not_modify_on_a_request_with_same_origin()
-    {
-        $app = $this->createStackedApp(array('allowedOrigins' => array('*')));
-        $unmodifiedResponse = new Response();
-
-        $request  = new Request();
-        $request->headers->set('Host', 'foo.com');
-        $request->headers->set('Origin', 'http://foo.com');
-        $response = $app->handle($request);
-        $unmodifiedResponse->headers->date = '';
-        $response->headers->date = '';
-
-        $this->assertEquals($unmodifiedResponse->headers, $response->headers);
-    }
-
-    /**
-     * @test
-     */
     public function it_returns_allow_origin_header_on_valid_actual_request()
     {
         $app      = $this->createStackedApp();
@@ -138,9 +107,10 @@ class CorsTest extends PHPUnit_Framework_TestCase
     /**
      * @test
      */
-    public function it_adds_a_vary_header_when_supports_credentials()
+    public function it_adds_a_vary_header_when_wildcard_and_supports_credentials()
     {
         $app      = $this->createStackedApp(array(
+            'allowedOrigins' => ['*'],
             'supportsCredentials' => true,
         ));
         $request  = $this->createValidActualRequest();
@@ -190,6 +160,7 @@ class CorsTest extends PHPUnit_Framework_TestCase
     {
         $app      = $this->createStackedApp(
             array(
+                'allowedOrigins' => ['*'],
                 'supportsCredentials' => true,
             ),
             array(

--- a/test/Asm89/Stack/CorsTest.php
+++ b/test/Asm89/Stack/CorsTest.php
@@ -52,19 +52,6 @@ class CorsTest extends PHPUnit_Framework_TestCase
     /**
      * @test
      */
-    public function it_returns_403_on_valid_actual_request_with_origin_not_allowed()
-    {
-        $app      = $this->createStackedApp(array('allowedOrigins' => array('notlocalhost')));
-        $request  = $this->createValidActualRequest();
-
-        $response = $app->handle($request);
-
-        $this->assertEquals(403, $response->getStatusCode());
-    }
-
-    /**
-     * @test
-     */
     public function it_returns_allow_origin_header_on_valid_actual_request()
     {
         $app      = $this->createStackedApp();

--- a/test/Asm89/Stack/CorsTest.php
+++ b/test/Asm89/Stack/CorsTest.php
@@ -21,6 +21,19 @@ class CorsTest extends PHPUnit_Framework_TestCase
     /**
      * @test
      */
+    public function it_does_not_modify_on_a_request_without_origin()
+    {
+        $app                = $this->createStackedApp();
+        $unmodifiedResponse = new Response();
+
+        $response = $app->handle(new Request());
+
+        $this->assertEquals($unmodifiedResponse->headers, $response->headers);
+    }
+
+    /**
+     * @test
+     */
     public function it_returns_allow_origin_header_on_valid_actual_request()
     {
         $app      = $this->createStackedApp();

--- a/test/Asm89/Stack/CorsTest.php
+++ b/test/Asm89/Stack/CorsTest.php
@@ -226,19 +226,6 @@ class CorsTest extends PHPUnit_Framework_TestCase
     /**
      * @test
      */
-    public function it_returns_403_on_valid_preflight_request_with_origin_not_allowed()
-    {
-        $app     = $this->createStackedApp(array('allowedOrigins' => array('notlocalhost')));
-        $request = $this->createValidPreflightRequest();
-
-        $response = $app->handle($request);
-
-        $this->assertEquals(403, $response->getStatusCode());
-    }
-
-    /**
-     * @test
-     */
     public function it_does_not_allow_request_with_origin_not_allowed()
     {
         $passedOptions = array(
@@ -274,19 +261,6 @@ class CorsTest extends PHPUnit_Framework_TestCase
     /**
      * @test
      */
-    public function it_returns_405_on_valid_preflight_request_with_method_not_allowed()
-    {
-        $app     = $this->createStackedApp(array('allowedMethods' => array('put')));
-        $request = $this->createValidPreflightRequest();
-
-        $response = $app->handle($request);
-
-        $this->assertEquals(405, $response->getStatusCode());
-    }
-
-    /**
-     * @test
-     */
     public function it_allow_methods_on_valid_preflight_request()
     {
         $app     = $this->createStackedApp(array('allowedMethods' => array('get', 'put')));
@@ -312,20 +286,6 @@ class CorsTest extends PHPUnit_Framework_TestCase
         $this->assertTrue($response->headers->has('Access-Control-Allow-Methods'));
         // it will return the Access-Control-Request-Method pass in the request
         $this->assertEquals('*', $response->headers->get('Access-Control-Allow-Methods'));
-    }
-
-    /**
-     * @test
-     */
-    public function it_returns_403_on_valid_preflight_request_with_one_of_the_requested_headers_not_allowed()
-    {
-        $app     = $this->createStackedApp();
-        $request = $this->createValidPreflightRequest();
-        $request->headers->set('Access-Control-Request-Headers', 'x-not-allowed-header');
-
-        $response = $app->handle($request);
-
-        $this->assertEquals(403, $response->getStatusCode());
     }
 
     /**

--- a/test/Asm89/Stack/CorsTest.php
+++ b/test/Asm89/Stack/CorsTest.php
@@ -31,6 +31,25 @@ class CorsTest extends PHPUnit_Framework_TestCase
         $this->assertEquals($unmodifiedResponse->headers, $response->headers);
     }
 
+
+    /**
+     * @test
+     */
+    public function it_does_not_modify_on_a_request_with_same_origin()
+    {
+        $app = $this->createStackedApp(array('allowedOrigins' => array('*')));
+        $unmodifiedResponse = new Response();
+
+        $request  = new Request();
+        $request->headers->set('Host', 'foo.com');
+        $request->headers->set('Origin', 'http://foo.com');
+        $response = $app->handle($request);
+        $unmodifiedResponse->headers->date = '';
+        $response->headers->date = '';
+
+        $this->assertEquals($unmodifiedResponse->headers, $response->headers);
+    }
+
     /**
      * @test
      */

--- a/test/Asm89/Stack/CorsTest.php
+++ b/test/Asm89/Stack/CorsTest.php
@@ -60,7 +60,7 @@ class CorsTest extends PHPUnit_Framework_TestCase
         $response = $app->handle($request);
 
         $this->assertEquals(204, $response->getStatusCode());
-        $this->assertEquals('FOO, BAR', $response->headers->get('Access-Control-Allow-Headers'));
+        $this->assertEquals('*', $response->headers->get('Access-Control-Allow-Headers'));
     }
 
     /**
@@ -311,7 +311,7 @@ class CorsTest extends PHPUnit_Framework_TestCase
 
         $this->assertTrue($response->headers->has('Access-Control-Allow-Methods'));
         // it will return the Access-Control-Request-Method pass in the request
-        $this->assertEquals('GET', $response->headers->get('Access-Control-Allow-Methods'));
+        $this->assertEquals('*', $response->headers->get('Access-Control-Allow-Methods'));
     }
 
     /**


### PR DESCRIPTION
If a simple origin check works, leave it to the browser, instead of changing the Origin ourselves.

Fixes #65 