### PR TITLE
Reflect headers/methods instead of wildcard

### DIFF
--- a/src/CorsService.php
+++ b/src/CorsService.php
@@ -166,12 +166,8 @@ class CorsService
     private function configureAllowedMethods(Response $response, Request $request)
     {
         if ($this->options['allowedMethods'] === true) {
-            if ($this->options['supportsCredentials']) {
-                $allowMethods = strtoupper($request->headers->get('Access-Control-Request-Method'));
-                $this->varyHeader($response, 'Access-Control-Request-Method');
-            } else {
-                $allowMethods = '*';
-            }
+            $allowMethods = strtoupper($request->headers->get('Access-Control-Request-Method'));
+            $this->varyHeader($response, 'Access-Control-Request-Method');
         } else {
             $allowMethods = implode(', ', $this->options['allowedMethods']);
         }
@@ -182,12 +178,8 @@ class CorsService
     private function configureAllowedHeaders(Response $response, Request $request)
     {
         if ($this->options['allowedHeaders'] === true) {
-            if ($this->options['supportsCredentials']) {
-                $allowHeaders = $request->headers->get('Access-Control-Request-Headers');
-                $this->varyHeader($response, 'Access-Control-Request-Headers');
-            } else {
-                $allowHeaders = '*';
-            }
+            $allowHeaders = $request->headers->get('Access-Control-Request-Headers');
+            $this->varyHeader($response, 'Access-Control-Request-Headers');
         } else {
             $allowHeaders = implode(', ', $this->options['allowedHeaders']);
         }

--- a/tests/CorsTest.php
+++ b/tests/CorsTest.php
@@ -89,7 +89,8 @@ class CorsTest extends TestCase
         $response = $app->handle($request);
 
         $this->assertEquals(204, $response->getStatusCode());
-        $this->assertEquals('*', $response->headers->get('Access-Control-Allow-Headers'));
+        $this->assertEquals('Foo, BAR', $response->headers->get('Access-Control-Allow-Headers'));
+        $this->assertEquals('Access-Control-Request-Headers, Access-Control-Request-Method', $response->headers->get('Vary'));
     }
 
     /**
@@ -395,7 +396,9 @@ class CorsTest extends TestCase
 
         $this->assertTrue($response->headers->has('Access-Control-Allow-Methods'));
         // it will return the Access-Control-Request-Method pass in the request
-        $this->assertEquals('*', $response->headers->get('Access-Control-Allow-Methods'));
+        $this->assertEquals('GET', $response->headers->get('Access-Control-Allow-Methods'));
+        $this->assertEquals('Access-Control-Request-Method', $response->headers->get('Vary'));
+
     }
 
     /**


### PR DESCRIPTION
Potential fix for https://github.com/fruitcake/laravel-cors/issues/460

This reverts to the 1.x behavior instead of using wildcards for the methods/headers. This will add some more Vary headers, but shouldn't be that problematic (it wasn't before)