### PR TITLE
PHP 8 Support

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,5 +1,6 @@
 on:
   push:
+  pull_request:
   schedule:
   - cron: '0 0 * * *'
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -9,7 +9,7 @@ jobs:
 
     strategy:
       matrix:
-        php: [7.4, 7.3, 7.2, 7.1, 7.0]
+        php: [8.0, 7.4, 7.3, 7.2, 7.1, 7.0]
         dependency-version: [prefer-lowest, prefer-stable]
         os: [ubuntu-latest]
 

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         }
     ],
     "require": {
-        "php": "^7.0",
+        "php": "^7.0|^8.0",
         "symfony/http-foundation": "~2.7|~3.0|~4.0|~5.0",
         "symfony/http-kernel": "~2.7|~3.0|~4.0|~5.0"
     },

--- a/src/CorsService.php
+++ b/src/CorsService.php
@@ -84,7 +84,7 @@ class CorsService
     public function addPreflightRequestHeaders(Response $response, Request $request): Response
     {
         $this->configureAllowedOrigin($response, $request);
-        
+
         if ($response->headers->has('Access-Control-Allow-Origin')) {
             $this->configureAllowCredentials($response, $request);
 


### PR DESCRIPTION
Hi there,

First of all thanks for maintaining this package :)

We're currently patching Laravel to install on PHP 8 and this package is blocking installs. I've added a PHP 8 build and updated the constraint in `composer.json`. All tests seem to pass. Would appreciate a merge and tag soon so people can start testing Laravel on PHP 8 👍 

PS. I've also fixed a whitespace issue which was failing the build.

Thanks!