### PR TITLE
Do not check isSameHost

### DIFF
--- a/src/CorsService.php
+++ b/src/CorsService.php
@@ -64,7 +64,7 @@ class CorsService
 
     public function isCorsRequest(Request $request): bool
     {
-        return $request->headers->has('Origin') && !$this->isSameHost($request);
+        return $request->headers->has('Origin');
     }
 
     public function isPreflightRequest(Request $request): bool


### PR DESCRIPTION
The isSameHost check can cause issues when using a proxy/cache like Cloudfront, which apparently changes the Origin header. We used this in v1 to add additional access checks, but this was removed in v2 because we rely on the Browser to handle proper security. 

So is this check required? The browser should only add Origin headers for CORS requests I think? So if it thinks it needs CORS, better accept that?

And we don't block access anyways.