### PR TITLE
Fix Access-Control-Allow-Origin null bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Bug with `Access-Control-Allow-Origin` header is `null` then `allowedOrigins` is `['*']`, `supportsCredentials` is `true` and `Origin` header doesn't  set (#85)
+
 ## [2.0.0] - 2020-05-11
 
 ### Added

--- a/src/CorsService.php
+++ b/src/CorsService.php
@@ -146,7 +146,7 @@ class CorsService
             $response->headers->set('Access-Control-Allow-Origin', array_values($this->options['allowedOrigins'])[0]);
         } else {
             // For dynamic headers, check the origin first
-            if ($this->isOriginAllowed($request)) {
+            if ($request->headers->has('Origin') && $this->isOriginAllowed($request)) {
                 $response->headers->set('Access-Control-Allow-Origin', $request->headers->get('Origin'));
             }
 

--- a/tests/CorsTest.php
+++ b/tests/CorsTest.php
@@ -518,6 +518,21 @@ class CorsTest extends TestCase
         $this->assertEquals(204, $response->getStatusCode());
     }
 
+    /**
+     * @test
+     */
+    public function it_doesnt_set_access_control_allow_origin_without_origin()
+    {
+        $app     = $this->createStackedApp([
+            'allowedOrigins'      => ['*'],
+            'supportsCredentials' => true,
+        ]);
+
+        $response = $app->handle(new Request);
+
+        $this->assertFalse($response->headers->has('Access-Control-Allow-Origin'));
+    }
+
     private function createValidActualRequest()
     {
         $request  = new Request();


### PR DESCRIPTION
### Fixed

- Bug with `Access-Control-Allow-Origin` header is `null` then `allowedOrigins` is `['*']`, `supportsCredentials` is `true` and `Origin` header doesn't  set (#85)


Closes: #85 