### PR TITLE
Remove unused Response import

### DIFF
--- a/src/Cors.php
+++ b/src/Cors.php
@@ -13,7 +13,6 @@ namespace Asm89\Stack;
 
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpFoundation\Response;
 
 class Cors implements HttpKernelInterface
 {


### PR DESCRIPTION
The alternative to removing the `Response` import is to typehint the `handle` method, seeing as that will return `Response`.