### PR TITLE
Re-support Symfony 4 and 5

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -10,7 +10,8 @@ jobs:
 
     strategy:
       matrix:
-        php: [8.0, 8.1]
+        php: [7.1, 7.2, 7.3, 7.4, 8.0, 8.1]
+        symfony: [4.x, 5.x, 6.x]
         dependency-version: [prefer-lowest, prefer-stable]
         os: [ubuntu-latest]
 
@@ -28,7 +29,8 @@ jobs:
 
     - name: Install dependencies
       run: |
-        composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction --no-suggest
+        composer require "symfony/http-foundation:${{ matrix.symfony }}" "symfony/http-kernel:${{ matrix.symfony }}" --no-interaction --no-update
+        composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction --no-suggest --with-all-dependencies
 
     - name: Execute Unit Tests
       run: vendor/bin/phpunit

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -15,15 +15,15 @@ jobs:
         dependency-version: [prefer-lowest, prefer-stable]
         os: [ubuntu-latest]
         exclude:
-          - symfony: ^5
+          - symfony: 5.x
             php: 7.1
-          - symfony: ^6
+          - symfony: 6.x
             php: 7.1
-          - symfony: ^6
+          - symfony: 6.x
             php: 7.2
-          - symfony: ^6
+          - symfony: 6.x
             php: 7.3
-          - symfony: ^6
+          - symfony: 6.x
             php: 7.4
 
     name: PHP${{ matrix.php }} - ${{ matrix.os }} - ${{ matrix.dependency-version }}

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -26,7 +26,7 @@ jobs:
           - symfony: 6.x
             php: 7.4
 
-    name: PHP${{ matrix.php }} - ${{ matrix.os }} - ${{ matrix.dependency-version }}
+    name: PHP${{ matrix.php }} Symfony${{ matrix.symfony }} - ${{ matrix.os }} - ${{ matrix.dependency-version }}
 
     steps:
     - name: Checkout code

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -24,7 +24,7 @@ jobs:
           - symfony: ^6
             php: 7.3
           - symfony: ^6
-              php: 7.4
+            php: 7.4
 
     name: PHP${{ matrix.php }} - ${{ matrix.os }} - ${{ matrix.dependency-version }}
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -14,6 +14,17 @@ jobs:
         symfony: [4.x, 5.x, 6.x]
         dependency-version: [prefer-lowest, prefer-stable]
         os: [ubuntu-latest]
+        exclude:
+          - symfony: ^5
+            php: 7.1
+          - symfony: ^6
+            php: 7.1
+          - symfony: ^6
+            php: 7.2
+          - symfony: ^6
+            php: 7.3
+          - symfony: ^6
+              php: 7.4
 
     name: PHP${{ matrix.php }} - ${{ matrix.os }} - ${{ matrix.dependency-version }}
 

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "symfony/http-kernel": "^4|^5|^6"
     },
     "require-dev": {
-        "phpunit/phpunit": "^7|^8|^9",
+        "phpunit/phpunit": "^7|^9",
         "squizlabs/php_codesniffer": "^3.5"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -12,12 +12,12 @@
         }
     ],
     "require": {
-        "php": "^8.0",
-        "symfony/http-foundation": "^6",
-        "symfony/http-kernel": "^6"
+        "php": "^7.1.3|^8.0",
+        "symfony/http-foundation": "^4|^5|^6",
+        "symfony/http-kernel": "^4|^5|^6"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9",
+        "phpunit/phpunit": "^7|^8|^9",
         "squizlabs/php_codesniffer": "^3.5"
     },
     "autoload": {

--- a/src/Cors.php
+++ b/src/Cors.php
@@ -43,7 +43,7 @@ class Cors implements HttpKernelInterface
         $this->cors = new CorsService(array_merge($this->defaultOptions, $options));
     }
 
-    public function handle(Request $request, int $type = HttpKernelInterface::MASTER_REQUEST, bool $catch = true): Response
+    public function handle(Request $request, $type = HttpKernelInterface::MASTER_REQUEST, $catch = true): Response
     {
         if ($this->cors->isPreflightRequest($request)) {
             $response = $this->cors->handlePreflightRequest($request);

--- a/src/Cors.php
+++ b/src/Cors.php
@@ -43,7 +43,7 @@ class Cors implements HttpKernelInterface
         $this->cors = new CorsService(array_merge($this->defaultOptions, $options));
     }
 
-    public function handle(Request $request, int $type = HttpKernelInterface::MAIN_REQUEST, bool $catch = true): Response
+    public function handle(Request $request, int $type = HttpKernelInterface::MASTER_REQUEST, bool $catch = true): Response
     {
         if ($this->cors->isPreflightRequest($request)) {
             $response = $this->cors->handlePreflightRequest($request);

--- a/tests/MockApp.php
+++ b/tests/MockApp.php
@@ -16,7 +16,7 @@ class MockApp implements HttpKernelInterface
         $this->responseHeaders = $responseHeaders;
     }
 
-    public function handle(Request $request, $type = HttpKernelInterface::MAIN_REQUEST, $catch = true): Response
+    public function handle(Request $request, $type = HttpKernelInterface::MASTER_REQUEST, $catch = true): Response
     {
         $response = new Response();
 

--- a/tests/MockApp.php
+++ b/tests/MockApp.php
@@ -16,7 +16,7 @@ class MockApp implements HttpKernelInterface
         $this->responseHeaders = $responseHeaders;
     }
 
-    public function handle(Request $request, int $type = HttpKernelInterface::MAIN_REQUEST, bool $catch = true): Response
+    public function handle(Request $request, $type = HttpKernelInterface::MAIN_REQUEST, $catch = true): Response
     {
         $response = new Response();
 


### PR DESCRIPTION
Following https://symfony.com/releases the 4.4 and 5.4 releases are still supported. Added matrix to test them, to make sure the type hints work.