### PR TITLE
Update README to reflect 2.x changes and spec compatibility.

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,19 +22,21 @@ This package can be used as a library or as [stack middleware].
 
 | Option                 | Description                                                | Default value |
 |------------------------|------------------------------------------------------------|---------------|
-| allowedMethods         | Matches the request method.                                | `[]`          |
-| allowedOrigins         | Matches the request origin.                                | `[]`          |
-| allowedOriginsPatterns | Matches the request origin with `preg_match`.              | `[]`          |
-| allowedHeaders         | Sets the Access-Control-Allow-Headers response header.     | `[]`          |
-| exposedHeaders         | Sets the Access-Control-Expose-Headers response header.    | `false`       |
-| maxAge                 | Sets the Access-Control-Max-Age response header.           | `false`       |
-| supportsCredentials    | Sets the Access-Control-Allow-Credentials header.          | `false`       |
+| `allowedMethods`         | Matches the request method.                                | `[]`          |
+| `allowedOrigins`         | Matches the request origin.                                | `[]`          |
+| `allowedOriginsPatterns` | Matches the request origin with `preg_match`.              | `[]`          |
+| `allowedHeaders`         | Sets the Access-Control-Allow-Headers response header.     | `[]`          |
+| `exposedHeaders`         | Sets the Access-Control-Expose-Headers response header.    | `false`       |
+| `maxAge`                 | Sets the Access-Control-Max-Age response header.<br/>Set to `null` to omit the header/use browser default.           | `0`       |
+| `supportsCredentials`    | Sets the Access-Control-Allow-Credentials header.          | `false`       |
 
 The _allowedMethods_ and _allowedHeaders_ options are case-insensitive.
 
 You don't need to provide both _allowedOrigins_ and _allowedOriginsPatterns_. If one of the strings passed matches, it is considered a valid origin.
 
 If `['*']` is provided to _allowedMethods_, _allowedOrigins_ or _allowedHeaders_ all methods / origins / headers are allowed.
+
+If _supportsCredentials_ is `true`, you must [explicitly set](https://fetch.spec.whatwg.org/#cors-protocol-and-credentials) `allowedHeaders` for any headers which are not CORS safelisted.
 
 ### Example: using the library
 
@@ -49,8 +51,8 @@ $cors = new CorsService([
     'allowedOrigins'         => ['http://localhost'],
     'allowedOriginsPatterns' => ['/localhost:\d/'],
     'exposedHeaders'         => false,
-    'maxAge'                 => false,
-    'supportsCredentials'    => false,
+    'maxAge'                 => 600,
+    'supportsCredentials'    => true,
 ]);
 
 $cors->addActualRequestHeaders(Response $response, $origin);
@@ -77,7 +79,7 @@ $app = new Cors($app, [
     // you can enter regexes that are matched to the origin request header
     'allowedOriginsPatterns' => ['/localhost:\d/'],
     'exposedHeaders'      => false,
-    'maxAge'              => false,
+    'maxAge'              => 600,
     'supportsCredentials' => false,
 ]);
 ```


### PR DESCRIPTION
The handling of `access-control-max-age` configuration was changed in https://github.com/asm89/stack-cors/commit/df153ceda9c83f6fe497907f72ab4f29c19c9b44 and then https://github.com/asm89/stack-cors/blame/7a198ec737e926eab15d29368fc6fff66772b0e2/src/CorsService.php#L205.

The `README` was not also updated, and in fact the default value of `false` would result in a cast to `0`, meaning users may be sending a shorter max age than they intend.