### PR TITLE
Support Symfony 7.

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -10,11 +10,14 @@ jobs:
 
     strategy:
       matrix:
-        php: [8.1, 8.2]
+        php: [8.1, 8.2, 8.3]
         symfony: [6.x]
         dependency-version: [prefer-lowest, prefer-stable]
         os: [ubuntu-latest]
         include:
+          - symfony: ^5.3
+            php: 7.3
+            dependency-version: prefer-lowest
           - symfony: ^5.3
             php: 7.3
             dependency-version: prefer-stable
@@ -27,6 +30,12 @@ jobs:
           - symfony: ^7
             php: 8.2
             dependency-version: prefer-lowest
+          - symfony: ^7
+            php: 8.2
+            dependency-version: prefer-stable
+          - symfony: ^7
+            php: 8.3
+            dependency-version: prefer-stable
 
     name: PHP${{ matrix.php }} Symfony${{ matrix.symfony }} - ${{ matrix.dependency-version }}
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -16,9 +16,6 @@ jobs:
         os: [ubuntu-latest]
         include:
           - symfony: ^5.3
-            php: 7.2
-            dependency-version: prefer-stable
-          - symfony: ^5.3
             php: 7.3
             dependency-version: prefer-stable
           - symfony: ^5.3

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         php: [8.1, 8.2]
-        symfony: [6.x, 7.x]
+        symfony: [6.x]
         dependency-version: [prefer-lowest, prefer-stable]
         os: [ubuntu-latest]
         include:
@@ -27,6 +27,9 @@ jobs:
           - symfony: ^5.3
             php: 8.1
             dependency-version: prefer-stable
+          - symfony: ^7
+            php: 8.2
+            dependency-version: prefer-lowest
 
     name: PHP${{ matrix.php }} Symfony${{ matrix.symfony }} - ${{ matrix.dependency-version }}
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -17,12 +17,16 @@ jobs:
         include:
           - symfony: 5.4.x
             php: 7.2
+            dependency-version: prefer-stable
           - symfony: 5.4.x
             php: 7.3
+            dependency-version: prefer-stable
           - symfony: 5.4.x
             php: 7.4
+            dependency-version: prefer-stable
           - symfony: 5.4.x
             php: 8.1
+            dependency-version: prefer-stable
 
     name: PHP${{ matrix.php }} Symfony${{ matrix.symfony }} - ${{ matrix.dependency-version }}
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   php-tests:
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
 
     strategy:
       matrix:
@@ -24,7 +24,7 @@ jobs:
           - symfony: 5.4.x
             php: 8.1
 
-    name: PHP${{ matrix.php }} Symfony${{ matrix.symfony }} - ${{ matrix.os }} - ${{ matrix.dependency-version }}
+    name: PHP${{ matrix.php }} Symfony${{ matrix.symfony }} - ${{ matrix.dependency-version }}
 
     steps:
     - name: Checkout code

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -15,16 +15,16 @@ jobs:
         dependency-version: [prefer-lowest, prefer-stable]
         os: [ubuntu-latest]
         include:
-          - symfony: 5.4.x
+          - symfony: ^5.3
             php: 7.2
             dependency-version: prefer-stable
-          - symfony: 5.4.x
+          - symfony: ^5.3
             php: 7.3
             dependency-version: prefer-stable
-          - symfony: 5.4.x
+          - symfony: ^5.3
             php: 7.4
             dependency-version: prefer-stable
-          - symfony: 5.4.x
+          - symfony: ^5.3
             php: 8.1
             dependency-version: prefer-stable
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -10,17 +10,19 @@ jobs:
 
     strategy:
       matrix:
-        php: [7.2, 7.3, 7.4, 8.0, 8.1]
-        symfony: [4.x, 5.x, 6.x]
+        php: [8.1, 8.2]
+        symfony: [6.x, 7.x]
         dependency-version: [prefer-lowest, prefer-stable]
         os: [ubuntu-latest]
-        exclude:
-          - symfony: 6.x
+        include:
+          - symfony: ^5.4
             php: 7.2
-          - symfony: 6.x
+          - symfony: ^5.4
             php: 7.3
-          - symfony: 6.x
+          - symfony: ^5.4
             php: 7.4
+          - symfony: ^5.4
+            php: 8.1
 
     name: PHP${{ matrix.php }} Symfony${{ matrix.symfony }} - ${{ matrix.os }} - ${{ matrix.dependency-version }}
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -15,13 +15,13 @@ jobs:
         dependency-version: [prefer-lowest, prefer-stable]
         os: [ubuntu-latest]
         include:
-          - symfony: ^5.4
+          - symfony: 5.4.x
             php: 7.2
-          - symfony: ^5.4
+          - symfony: 5.4.x
             php: 7.3
-          - symfony: ^5.4
+          - symfony: 5.4.x
             php: 7.4
-          - symfony: ^5.4
+          - symfony: 5.4.x
             php: 8.1
 
     name: PHP${{ matrix.php }} Symfony${{ matrix.symfony }} - ${{ matrix.os }} - ${{ matrix.dependency-version }}

--- a/composer.json
+++ b/composer.json
@@ -40,4 +40,6 @@
             "dev-master": "2.1-dev"
         }
     }
+    "minimum-stability": "beta",
+    "prefer-stable": true
 }

--- a/composer.json
+++ b/composer.json
@@ -13,8 +13,8 @@
     ],
     "require": {
         "php": "^7.2|^8.0",
-        "symfony/http-foundation": "^6|^7",
-        "symfony/http-kernel": "^6|^7"
+        "symfony/http-foundation": "^5.3|^6|^7",
+        "symfony/http-kernel": "^5.3|^6|^7"
     },
     "require-dev": {
         "phpunit/phpunit": "^9",

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         }
     ],
     "require": {
-        "php": "^7.2|^8.0",
+        "php": "^7.3|^8.0",
         "symfony/http-foundation": "^5.3|^6|^7",
         "symfony/http-kernel": "^5.3|^6|^7"
     },

--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
         "branch-alias": {
             "dev-master": "2.1-dev"
         }
-    }
+    },
     "minimum-stability": "beta",
     "prefer-stable": true
 }

--- a/composer.json
+++ b/composer.json
@@ -13,11 +13,11 @@
     ],
     "require": {
         "php": "^7.2|^8.0",
-        "symfony/http-foundation": "^4|^5|^6",
-        "symfony/http-kernel": "^4|^5|^6"
+        "symfony/http-foundation": "^6|^7",
+        "symfony/http-kernel": "^6|^7"
     },
     "require-dev": {
-        "phpunit/phpunit": "^7|^9",
+        "phpunit/phpunit": "^9",
         "squizlabs/php_codesniffer": "^3.5"
     },
     "autoload": {

--- a/src/Cors.php
+++ b/src/Cors.php
@@ -43,7 +43,7 @@ class Cors implements HttpKernelInterface
         $this->cors = new CorsService(array_merge($this->defaultOptions, $options));
     }
 
-    public function handle(Request $request, $type = HttpKernelInterface::MASTER_REQUEST, $catch = true): Response
+    public function handle(Request $request, $type = HttpKernelInterface::MAIN_REQUEST, $catch = true): Response
     {
         if ($this->cors->isPreflightRequest($request)) {
             $response = $this->cors->handlePreflightRequest($request);

--- a/src/Cors.php
+++ b/src/Cors.php
@@ -43,7 +43,7 @@ class Cors implements HttpKernelInterface
         $this->cors = new CorsService(array_merge($this->defaultOptions, $options));
     }
 
-    public function handle(Request $request, $type = HttpKernelInterface::MAIN_REQUEST, $catch = true): Response
+    public function handle(Request $request, int $type = HttpKernelInterface::MAIN_REQUEST, bool $catch = true): Response
     {
         if ($this->cors->isPreflightRequest($request)) {
             $response = $this->cors->handlePreflightRequest($request);

--- a/tests/MockApp.php
+++ b/tests/MockApp.php
@@ -16,7 +16,7 @@ class MockApp implements HttpKernelInterface
         $this->responseHeaders = $responseHeaders;
     }
 
-    public function handle(Request $request, $type = HttpKernelInterface::MAIN_REQUEST, $catch = true): Response
+    public function handle(Request $request, int $type = HttpKernelInterface::MAIN_REQUEST, bool $catch = true): Response
     {
         $response = new Response();
 

--- a/tests/MockApp.php
+++ b/tests/MockApp.php
@@ -16,7 +16,7 @@ class MockApp implements HttpKernelInterface
         $this->responseHeaders = $responseHeaders;
     }
 
-    public function handle(Request $request, $type = HttpKernelInterface::MASTER_REQUEST, $catch = true): Response
+    public function handle(Request $request, $type = HttpKernelInterface::MAIN_REQUEST, $catch = true): Response
     {
         $response = new Response();
 


### PR DESCRIPTION
Symfony has dropped the `MASTER_REQUEST` constant in Symfony 7 so we have to switch to `MAIN_REQUEST` and drop support for older versions of Symfony.
