### PR TITLE
Check and save multiple Vary Headers

### DIFF
--- a/src/CorsService.php
+++ b/src/CorsService.php
@@ -211,8 +211,20 @@ class CorsService
     {
         if (!$response->headers->has('Vary')) {
             $response->headers->set('Vary', $header);
-        } elseif (!in_array($header, explode(', ', $response->headers->get('Vary')))) {
-            $response->headers->set('Vary', $response->headers->get('Vary') . ', ' . $header);
+        } else {
+            $varyHeaders = $response->headers->all('Vary');
+            $existing = [];
+            foreach ($varyHeaders as $value) {
+                $existing = array_merge($existing, explode(', ', $value));
+            }
+
+            if (!in_array($header, $existing)) {
+                if (count($varyHeaders) < 2) {
+                    $response->headers->set('Vary', $response->headers->get('Vary') . ', ' . $header);
+                } else {
+                    $response->headers->set('Vary', $header, false);
+                }
+            }
         }
 
         return $response;

--- a/src/CorsService.php
+++ b/src/CorsService.php
@@ -211,7 +211,7 @@ class CorsService
     {
         $vary = $response->getVary();
         if (!in_array($header, $vary)) {
-            if (count($response->headers->all('Vary')) == 1) {
+            if (count($response->headers->all('Vary')) === 1) {
                 $response->setVary($response->headers->get('Vary') . ', ' . $header, true);
             } else {
                 $response->setVary($header, false);

--- a/src/CorsService.php
+++ b/src/CorsService.php
@@ -209,21 +209,12 @@ class CorsService
 
     public function varyHeader(Response $response, $header): Response
     {
-        if (!$response->headers->has('Vary')) {
-            $response->headers->set('Vary', $header);
-        } else {
-            $varyHeaders = $response->headers->all('Vary');
-            $existing = [];
-            foreach ($varyHeaders as $value) {
-                $existing = array_merge($existing, explode(', ', $value));
-            }
-
-            if (!in_array($header, $existing)) {
-                if (count($varyHeaders) < 2) {
-                    $response->headers->set('Vary', $response->headers->get('Vary') . ', ' . $header);
-                } else {
-                    $response->headers->set('Vary', $header, false);
-                }
+        $vary = $response->getVary();
+        if (!in_array($header, $vary)) {
+            if (count($response->headers->all('Vary')) == 1) {
+                $response->setVary($response->headers->get('Vary') . ', ' . $header, true);
+            } else {
+                $response->setVary($header, false);
             }
         }
 

--- a/src/CorsService.php
+++ b/src/CorsService.php
@@ -210,7 +210,7 @@ class CorsService
     public function varyHeader(Response $response, $header): Response
     {
         $vary = $response->getVary();
-        if (!in_array($header, $vary)) {
+        if (!in_array($header, $vary, true)) {
             if (count($response->headers->all('Vary')) === 1) {
                 $response->setVary($response->headers->get('Vary') . ', ' . $header, true);
             } else {

--- a/tests/CorsTest.php
+++ b/tests/CorsTest.php
@@ -271,6 +271,76 @@ class CorsTest extends TestCase
         $this->assertEquals('Content-Type, Origin', $response->headers->get('Vary'));
     }
 
+
+    /**
+     * @test
+     * @see http://www.w3.org/TR/cors/index.html#resource-implementation
+     */
+    public function it_doesnt_append_an_existing_vary_header_when_exists()
+    {
+        $app      = $this->createStackedApp(
+            array(
+                'allowedOrigins' => ['*'],
+                'supportsCredentials' => true,
+            ),
+            array(
+                'Vary' => 'Content-Type, Origin'
+            )
+        );
+        $request  = $this->createValidActualRequest();
+
+        $response = $app->handle($request);
+
+        $this->assertTrue($response->headers->has('Vary'));
+        $this->assertEquals('Content-Type, Origin', $response->headers->get('Vary'));
+    }
+
+    /**
+     * @test
+     * @see http://www.w3.org/TR/cors/index.html#resource-implementation
+     */
+    public function it_appends_an_existing_vary_header_when_multiple()
+    {
+        $app      = $this->createStackedApp(
+            array(
+                'allowedOrigins' => ['*'],
+                'supportsCredentials' => true,
+            ),
+            array(
+                'Vary' => ['Content-Type', 'Referer'],
+            )
+        );
+        $request  = $this->createValidActualRequest();
+
+        $response = $app->handle($request);
+
+        $this->assertTrue($response->headers->has('Vary'));
+        $this->assertEquals(['Content-Type' ,'Referer', 'Origin'], $response->headers->all('Vary'));
+    }
+
+    /**
+     * @test
+     * @see http://www.w3.org/TR/cors/index.html#resource-implementation
+     */
+    public function it_doesnt_append_an_existing_vary_header_when_exists_multiple()
+    {
+        $app      = $this->createStackedApp(
+            array(
+                'allowedOrigins' => ['*'],
+                'supportsCredentials' => true,
+            ),
+            array(
+                'Vary' => ['Content-Type', 'Referer', 'Origin'],
+            )
+        );
+        $request  = $this->createValidActualRequest();
+
+        $response = $app->handle($request);
+
+        $this->assertTrue($response->headers->has('Vary'));
+        $this->assertEquals(['Content-Type' ,'Referer', 'Origin'], $response->headers->all('Vary'));
+    }
+
     /**
      * @test
      */


### PR DESCRIPTION
Resolves #105
Replaced #107

When multiple Vary headers are set, Symfony only returns the first one. When replacing the Vary header, it removes the 2nd one. This changes behavior so that in the case multiple headers are used, it check all existing Vary headers and appends it as a new header. This will result in an additional Vary header but only when there were already 2 or more.