### PR TITLE
Allow Symfony 8.

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -37,6 +37,12 @@ jobs:
           - symfony: ^7
             php: 8.4
             dependency-version: prefer-stable
+          - symfony: ^8
+            php: 8.4
+            dependency-version: prefer-lowest
+          - symfony: ^8
+            php: 8.5
+            dependency-version: prefer-stable
 
     name: PHP${{ matrix.php }} Symfony${{ matrix.symfony }} - ${{ matrix.dependency-version }}
 

--- a/composer.json
+++ b/composer.json
@@ -13,8 +13,8 @@
     ],
     "require": {
         "php": "^7.3|^8.0",
-        "symfony/http-foundation": "^5.3|^6|^7",
-        "symfony/http-kernel": "^5.3|^6|^7"
+        "symfony/http-foundation": "^5.3|^6|^7|^8",
+        "symfony/http-kernel": "^5.3|^6|^7|^8"
     },
     "require-dev": {
         "phpunit/phpunit": "^9",


### PR DESCRIPTION
Drupal depends on this package and Drupal 12 will ship with Symfony 8, so we need to bump the dependency here as well.

Added Symfony 8 to the test matrix as well. Thanks to the work last time in #104 this seems simpler this time round!